### PR TITLE
Fix Installer crashes

### DIFF
--- a/pyfomod/installer.py
+++ b/pyfomod/installer.py
@@ -280,7 +280,7 @@ class Installer(object):
     def flags(self):
         flag_dict = {}
         flags_list = [
-            option._object.flags
+            option.flags
             for info in self._previous_pages
             for option in info.options
         ]

--- a/pyfomod/installer.py
+++ b/pyfomod/installer.py
@@ -256,7 +256,7 @@ class Installer(object):
             file_info
             for info in self._previous_pages
             for option in info.options
-            for file_info in FileInfo.process_files(option._object.files, self.path)
+            for file_info in FileInfo.process_files(option.files, self.path)
         ]
         conditional_files = []
         for conditions, files in self.root.file_patterns.items():

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -347,11 +347,7 @@ class TestInstaller(object):
         files2._file_list = [file2, file3]
         option2 = fomod.Option()
         option2.files = files2
-        installer_mock._previous_pages = [
-            installer.PageInfo(
-                None, [installer.InstallerOption(installer_mock, option2)]
-            )
-        ]
+        installer_mock._previous_pages = [installer.PageInfo(None, [option2])]
         files3 = fomod.Files()
         file4 = fomod.File("file", attrib={"priority": "1"})
         file4.src = "source4"
@@ -376,16 +372,8 @@ class TestInstaller(object):
         option3 = fomod.Option()
         option3.flags = flags3
         installer_mock._previous_pages = [
-            installer.PageInfo(
-                None, [installer.InstallerOption(installer_mock, option1)]
-            ),
-            installer.PageInfo(
-                None,
-                [
-                    installer.InstallerOption(installer_mock, option2),
-                    installer.InstallerOption(installer_mock, option3),
-                ],
-            ),
+            installer.PageInfo(None, [option1]),
+            installer.PageInfo(None, [option2, option3]),
         ]
         expected = {"flag1": "value3", "flag2": "value2"}
         assert installer.Installer.flags(installer_mock) == expected


### PR DESCRIPTION
Options in `info.options` are already of `Option` type, not
`InstallerOption`, hence the `option._object` call fails with e.g.:

```
  File "/home/lahvuun/git/cemm/cemm_venv/lib/python3.6/site-packages/pyfomod/installer.py", line 284, in flags
    for info in self._previous_pages
  File "/home/lahvuun/git/cemm/cemm_venv/lib/python3.6/site-packages/pyfomod/installer.py", line 285, in <listcomp>
    for option in info.options
AttributeError: 'Option' object has no attribute '_object'
```

Probably a leftover from a local revision.