### PR TITLE
Allow for options with same destination

### DIFF
--- a/src/pyfomod/installer.py
+++ b/src/pyfomod/installer.py
@@ -261,16 +261,13 @@ class Installer(object):
                 pass
             else:
                 conditional_files.extend(FileInfo.process_files(files, self.path))
-        file_dict = {}  # src -> dst
-        priority_dict = {}  # dst -> priority
+        files = []
         for info in required_files + user_files + conditional_files:
-            if info.destination in priority_dict:
-                if priority_dict[info.destination] > info.priority:
-                    continue
-                del file_dict[info.destination]
-            file_dict[info.destination] = info.source
-            priority_dict[info.destination] = info.priority
-        return {b: a for a, b in file_dict.items()}
+            files.append(info)
+        return [
+            (f.source, f.destination) 
+            for f in sorted(files, key=lambda f: f.priority)
+        ]
 
     def flags(self):
         flag_dict = {}


### PR DESCRIPTION
Proposed fix for #9. Returned files are sorted with priority to allow for overwriting the directory with higher priority files.

fixes #9