### PR TITLE
Fix installer's handling of duplicate directory paths

### DIFF
--- a/src/pyfomod/installer.py
+++ b/src/pyfomod/installer.py
@@ -267,13 +267,8 @@ class Installer(object):
         file_dict = {}  # src -> dst
         priority_dict = {}  # dst -> priority
         for info in required_files + user_files + conditional_files:
-            if info.destination in priority_dict:
-                if priority_dict[info.destination] > info.priority:
-                    continue
-                del file_dict[info.destination]
-            file_dict[info.destination] = info.source
-            priority_dict[info.destination] = info.priority
-        return {b: a for a, b in file_dict.items()}
+            file_dict[info.source] = info.destination
+        return {a: b for a, b in file_dict.items()}
 
     def flags(self):
         flag_dict = {}

--- a/src/pyfomod/installer.py
+++ b/src/pyfomod/installer.py
@@ -264,11 +264,10 @@ class Installer(object):
                 pass
             else:
                 conditional_files.extend(FileInfo.process_files(files, self.path))
-        file_dict = {}  # src -> dst
-        priority_dict = {}  # dst -> priority
-        for info in required_files + user_files + conditional_files:
+        file_dict = OrderedDict()  # src -> dst
+        for info in sorted(required_files + user_files + conditional_files,key=lambda i:i.priority):
             file_dict[info.source] = info.destination
-        return {a: b for a, b in file_dict.items()}
+        return file_dict
 
     def flags(self):
         flag_dict = {}


### PR DESCRIPTION
Fixes #15

Instead of having a separate `priority_dict`, this now sorts all files to be installed into an `OrderedDict` which doesn't overwrite based on the destination path, but simply provides the correct order to copy paths so that higher priority files overwrite lower priority files while directories can get merged (depending on which tool is used to copy).

This introduces a slight inefficiency insofar as duplicate files will get returned twice and, without further parsing, might be copied over each other, but the installer cannot know for certain if a path is a file or a folder.